### PR TITLE
Fix superfluent underscore in win32.kernel32.GetThreadId()

### DIFF
--- a/winappdbg/win32/kernel32.py
+++ b/winappdbg/win32/kernel32.py
@@ -4045,7 +4045,7 @@ def GetProcessId(hProcess):
 #   __in  HANDLE hThread
 # );
 def GetThreadId(hThread):
-    _GetThreadId = windll.kernel32._GetThreadId
+    _GetThreadId = windll.kernel32.GetThreadId
     _GetThreadId.argtypes = [HANDLE]
     _GetThreadId.restype  = DWORD
 


### PR DESCRIPTION
The function `win32.kernel32.GetThreadId()` tries to access the nonexistant function `windll.kernel32._GetThreadId`, which raises an `AttributeError`.

Instead, `windll.kernel32.GetThreadId` (without underscore) should be used.