### PR TITLE
Bug/get symbol from list local var use before assignment

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -40,6 +40,11 @@ class ModuleTests(unittest.TestCase):
 
     @mock.patch('winappdbg.Module.iter_symbols')
     def test_get_symbol_at_address(self, mock_iter_symbols):
+
+        mock_iter_symbols.return_value = []
+
+        self.assertSymbolAtAddressEqual(0x1234, None)
+
         mock_iter_symbols.return_value = [("matchPattern", 0x002A, 0x10),
                                         ("isMatched", 0xFF42, 0x0090),
                                         ("__ii_95", 0x0102, 0),
@@ -50,9 +55,11 @@ class ModuleTests(unittest.TestCase):
                                         ("numGroups", 0x001F, 0),
                                         ("__comp_state", 0x003C, 0x0004)]
 
+        self.assertSymbolAtAddressEqual(0x0009, None)
         self.assertSymbolAtAddressEqual(0x000A, ("groupSize", 0x000A, 0))
         self.assertSymbolAtAddressEqual(0x0029, ("numGroups", 0x001F, 0))
         self.assertSymbolAtAddressEqual(0x0141, ("iter_int32", 0x009E, 0x00A4))
         self.assertSymbolAtAddressEqual(0x0142, ("__jj_49", 0x0140, 0))
-        self.assertSymbolAtAddressEqual(0x493F, ("__ref_thesaurus", 0x1000, 0))
+        self.assertSymbolAtAddressEqual(0x493F,
+                                        ("__ref_thesaurus", 0x1000, 0x07F0))
         self.assertSymbolAtAddressEqual(0xFF7A, ("isMatched", 0xFF42, 0x0090))

--- a/winappdbg/module.py
+++ b/winappdbg/module.py
@@ -600,21 +600,24 @@ class Module (object):
             Returns C{None} if no symbol could be matched.
         """
 
-        res = None
+        match = None
 
         for Symbol in self.iter_symbols():
             SymbolName, SymbolAddress, SymbolSize = Symbol
 
             if SymbolAddress <= address:
-                symBeginsAfterMatch = res and SymbolAddress > res[1]
+                symBeginsAfterMatch = match and SymbolAddress > match[1]
                 symIncludesAddr = SymbolAddress + SymbolSize > address
+                matchIncludesAddr = match and match[1] + match[2] > address
 
-                if (not res
-                    or not res[2] and (symBeginsAfterMatch or symIncludesAddr)
-                    or res[2] and symBeginsAfterMatch and symIncludesAddr):
-                    res = symbol
+                if (not match
+                    or not matchIncludesAddr
+                        and (symBeginsAfterMatch or symIncludesAddr)
+                    or matchIncludesAddr
+                        and (symBeginsAfterMatch and symIncludesAddr)):
+                    match = Symbol
 
-            return res
+        return match
 
 #------------------------------------------------------------------------------
 

--- a/winappdbg/module.py
+++ b/winappdbg/module.py
@@ -585,23 +585,6 @@ class Module (object):
                 if symbol == SymbolName.lower():
                     return SymbolAddress
 
-    def get_symbol_from_list(self,address):
-        found = None
-        SymList = {}
-        SortedSymList = {}
-
-        for (SymbolName, SymbolAddress, SymbolSize) in self.iter_symbols():
-            SymList[SymbolAddress] = SymbolName
-        SortedSymList = sorted(SymList.items())
-        for SymbolAddress,SymbolName in SortedSymList:
-            if SymbolAddress <= address:
-                SymbolStartAddress = SymbolAddress
-                SymbolStartName = SymbolName
-            else:
-                break
-        found = (SymbolStartName, SymbolStartAddress, 0)
-        return found
-
     def get_symbol_at_address(self, address):
         """
         Tries to find the closest matching symbol for the given address.
@@ -616,17 +599,22 @@ class Module (object):
              - Size (in bytes)
             Returns C{None} if no symbol could be matched.
         """
-        found = None
-        for (SymbolName, SymbolAddress, SymbolSize) in self.iter_symbols():
 
-            if SymbolAddress > address:
-                continue
-            if SymbolAddress + SymbolSize > address:
-                if not found or found[1] < SymbolAddress:
-                    found = (SymbolName, SymbolAddress, SymbolSize)
-        if found == None:
-            found = self.get_symbol_from_list(address)
-        return found
+        res = None
+
+        for Symbol in self.iter_symbols():
+            SymbolName, SymbolAddress, SymbolSize = Symbol
+
+            if SymbolAddress <= address:
+                symBeginsAfterMatch = res and SymbolAddress > res[1]
+                symIncludesAddr = SymbolAddress + SymbolSize > address
+
+                if (not res
+                    or not res[2] and (symBeginsAfterMatch or symIncludesAddr)
+                    or res[2] and symBeginsAfterMatch and symIncludesAddr):
+                    res = symbol
+
+            return res
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #60. I've extended the unit tests to cover the error. Some things to notice about this pull requests:

- I've consolidated the logic into a single function and removed the new `get_symbol_from_list`. It seems that it was never intended to be part of the interface so no harm done there.

- `get_symbol_list` was nullifying the size of the returned symbol. I see no reason for that so now the size is left intact.

- I've refactored the names to make it more clear what the function is doing. It looks for the symbol with the closest starting address <= address where symbols which fully contain the address have priority.

PS: perhaps somebody can do a quick review =)