### PR TITLE
Fix can't concat str to bytes error when using _peek_c_type function

### DIFF
--- a/winappdbg/process.py
+++ b/winappdbg/process.py
@@ -1992,7 +1992,9 @@ class Process (_ThreadContainer, _ModuleContainer):
         size = ctypes.sizeof(c_type)
         packed = self.peek(address, size)
 
-        if len(packed) < size:
+        if len(packed) == 0:
+            packed = b'\0' * size
+        elif len(packed) < size:
             packed = b'\0' * (size - len(packed)) + packed
         elif len(packed) > size:
             packed = packed[:size]


### PR DESCRIPTION
Added a check if the result is empty then set the value to 0 instead of trying to concat a string and a byte array.

Related to #74.