### PR TITLE
Fix issue caused by WriteProcessMemory not always writing all bytes

### DIFF
--- a/winappdbg/process.py
+++ b/winappdbg/process.py
@@ -1838,7 +1838,7 @@ class Process(_ThreadContainer, _ModuleContainer):
         length = org_length
         if prot is not None:
             try:
-                self.mprotect(lpBaseAddress, org_length, prot)
+                self.mprotect(org_lpBaseAddress, org_length, prot)
             except Exception:
                 prot = None
                 msg = (
@@ -1852,7 +1852,7 @@ class Process(_ThreadContainer, _ModuleContainer):
                 warnings.warn(msg, RuntimeWarning)
         try:
             while length:
-                r = win32.WriteProcessMemory(hProcess, org_lpBaseAddress, lpBuffer)
+                r = win32.WriteProcessMemory(hProcess, lpBaseAddress, lpBuffer)
                 length -= r
                 lpBaseAddress += r
                 lpBuffer = lpBuffer[r:]
@@ -4688,6 +4688,7 @@ class _ProcessContainer:
         if dwProcessId in self.__processDict:
             self._del_process(dwProcessId)
         return True
+
 
 
 

--- a/winappdbg/process.py
+++ b/winappdbg/process.py
@@ -1834,6 +1834,7 @@ class Process(_ThreadContainer, _ModuleContainer):
         else:
             prot = win32.PAGE_READWRITE
         org_length = len(lpBuffer)
+        org_lpBaseAddress = lpBaseAddress
         length = org_length
         if prot is not None:
             try:
@@ -1851,13 +1852,13 @@ class Process(_ThreadContainer, _ModuleContainer):
                 warnings.warn(msg, RuntimeWarning)
         try:
             while length:
-                r = win32.WriteProcessMemory(hProcess, lpBaseAddress, lpBuffer)
+                r = win32.WriteProcessMemory(hProcess, org_lpBaseAddress, lpBuffer)
                 length -= r
                 lpBaseAddress += r
                 lpBuffer = lpBuffer[r:]
         finally:
             if prot is not None:
-                self.mprotect(lpBaseAddress, org_length, mbi.Protect)
+                self.mprotect(org_lpBaseAddress, org_length, mbi.Protect)
         return org_length
 
     def peek_char(self, lpBaseAddress):
@@ -4687,5 +4688,6 @@ class _ProcessContainer:
         if dwProcessId in self.__processDict:
             self._del_process(dwProcessId)
         return True
+
 
 

--- a/winappdbg/process.py
+++ b/winappdbg/process.py
@@ -1837,7 +1837,7 @@ class Process(_ThreadContainer, _ModuleContainer):
         length = org_length
         if prot is not None:
             try:
-                self.mprotect(lpBaseAddress, len(lpBuffer), prot)
+                self.mprotect(lpBaseAddress, org_length, prot)
             except Exception:
                 prot = None
                 msg = (
@@ -1857,7 +1857,7 @@ class Process(_ThreadContainer, _ModuleContainer):
                 lpBuffer = lpBuffer[r:]
         finally:
             if prot is not None:
-                self.mprotect(lpBaseAddress, len(lpBuffer), mbi.Protect)
+                self.mprotect(lpBaseAddress, org_length, mbi.Protect)
         return org_length
 
     def peek_char(self, lpBaseAddress):
@@ -4687,4 +4687,5 @@ class _ProcessContainer:
         if dwProcessId in self.__processDict:
             self._del_process(dwProcessId)
         return True
+
 

--- a/winappdbg/process.py
+++ b/winappdbg/process.py
@@ -1853,6 +1853,8 @@ class Process(_ThreadContainer, _ModuleContainer):
         try:
             while length:
                 r = win32.WriteProcessMemory(hProcess, lpBaseAddress, lpBuffer)
+                if r == 0:
+                    break
                 length -= r
                 lpBaseAddress += r
                 lpBuffer = lpBuffer[r:]
@@ -4688,6 +4690,7 @@ class _ProcessContainer:
         if dwProcessId in self.__processDict:
             self._del_process(dwProcessId)
         return True
+
 
 
 


### PR DESCRIPTION
WriteProcessMemory returns the number of bytes written and it does not always write all bytes in one go. This patch makes sure that all bytes are written.

Most if not all functions that use poke() assume that all bytes are written. This makes sure that all those functions work as intended.

def write() is even built to assume that a windows error has occurred when all bytes have not been written by poke() which is wrong. WriteProcessMemory may simply not write all bytes it is expected behavior.
This patch fixes a bunch of such issues.